### PR TITLE
Swap axe-matchers for axe-core-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development do
 end
 
 group :test do
-  gem "axe-matchers"
+  gem "axe-core-rspec"
   gem "rspec_junit_formatter"
   gem "rspec-retry"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,13 +110,10 @@ GEM
       ruby2_keywords (>= 0.0.2)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
-    axe-matchers (2.6.1)
-      dumb_delegator (~> 0.8)
-      virtus (~> 1.0)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
+    axe-core-api (4.12.0)
+      dumb_delegator
+    axe-core-rspec (4.12.0)
+      axe-core-api (= 4.12.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -156,8 +153,6 @@ GEM
       logger (~> 1.5)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.7)
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -178,8 +173,6 @@ GEM
     delayed_job_active_record (4.1.11)
       activerecord (>= 3.0, < 9.0)
       delayed_job (>= 3.0, < 5)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -196,8 +189,7 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.3)
-    dumb_delegator (0.8.1)
-    equalizer (0.0.11)
+    dumb_delegator (1.1.0)
     erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -226,7 +218,6 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     ice_cube (0.17.0)
-    ice_nine (0.11.2)
     inherited_resources (1.14.0)
       actionpack (>= 6.0)
       has_scope (>= 0.6)
@@ -446,7 +437,6 @@ GEM
     ssrf_filter (1.5.0)
     stimulusjs-rails (1.1.1)
     thor (1.5.0)
-    thread_safe (0.3.6)
     tilt (2.8.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -458,11 +448,6 @@ GEM
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
     useragent (0.16.11)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -487,7 +472,7 @@ DEPENDENCIES
   activeadmin
   acts_as_list
   autoprefixer-rails
-  axe-matchers
+  axe-core-rspec
   babel-transpiler
   bootsnap (>= 1.1.0)
   bootstrap (~> 5)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require File.expand_path("../config/environment", __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
 require "capybara/rspec"
-require "axe/rspec"
+require "axe-rspec"
 require "rspec/retry"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 

--- a/spec/support/behaviors.rb
+++ b/spec/support/behaviors.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples "accessible" do
   it "should be accessible" do
-    expect(page).to be_accessible
+    expect(page).to be_axe_clean
   end
 end
 


### PR DESCRIPTION
Replaces the abandoned axe-matchers (2018) with Deque's current axe-core-rspec 4.12, keeping the homepage accessibility check real (`be_accessible` → `be_axe_clean`).

Net lockfile: −8 gems (axe-matchers plus the dead Virtus tree: virtus, axiom-types, coercible, descendants_tracker, equalizer, ice_nine, thread_safe), +2 (axe-core-rspec, axe-core-api). Homepage passes the much newer axe-core 4.12 ruleset with no exclusions; the matcher was verified to actually fail on an injected violation.

With this, virtus is fully out of the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrrkF26nwrxjuCiycos5xz